### PR TITLE
Fix typos found by jetls

### DIFF
--- a/src/operators/op.jl
+++ b/src/operators/op.jl
@@ -37,6 +37,6 @@ Base.isapprox(op1::Op, op2::Op, rtol::Float64=1e-12, atol::Float64=1e-12)::Bool 
 Base.:(==)(op1::Op, op2::Op)::Bool = Bool(op1.cxx_op == op2.cxx_op)
 
 # Output
-to_string(op::Op)::String = to_string(ops.cxx_op)
+to_string(op::Op)::String = to_string(op.cxx_op)
 Base.show(io::IO, op::Op) = print(io, to_string(op.cxx_op))
 

--- a/src/states/random_state.jl
+++ b/src/states/random_state.jl
@@ -11,7 +11,7 @@ RandomState(seed::Int64 = 42, normalized::Bool = true) = RandomState(construct_R
 
 # Methods
 seed(state::RandomState) = seed(state.cxx_random_state)
-normalized(state::RandomState) = seed(state.cxx_random_state)
+normalized(state::RandomState) = normalized(state.cxx_random_state)
     
 # Output
 to_string(state::RandomState)::String = to_string(state.cxx_random_state)

--- a/src/symmetries/permutation_group.jl
+++ b/src/symmetries/permutation_group.jl
@@ -9,7 +9,7 @@ convert(::Type{T}, g::cxx_PermutationGroup) where T <: PermutationGroup =
     PermutationGroup(g)
 
 # Constructors
-PermutationGroup() = Permutation(construct_PermutationGroup())
+PermutationGroup() = PermutationGroup(construct_PermutationGroup())
 function PermutationGroup(matrix::Matrix{Int64})
     matrix0 = matrix .- 1
     m, n = size(matrix0)


### PR DESCRIPTION
## Summary
This PR fixes typos found by `jetls check`.


## Changes
- Fix `Op.to_string` to reference `op.cxx_op` instead of an undefined `ops` variable.
- Fix `RandomState.normalized` to call `normalized` instead of `seed`.
- Fix `PermutationGroup()` to wrap `construct_PermutationGroup()` as a `PermutationGroup` instead of a `Permutation`.

